### PR TITLE
Diffing tool now takes arguments and outputs to txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 PhotoFlare.pro.user
 .DS_Store
+.vscode/

--- a/languages/diffing_tool.py
+++ b/languages/diffing_tool.py
@@ -15,10 +15,8 @@ for lang_short in sys.argv[1:]:
 
     for lang_string in LANG_FILE:
         lang_string = lang_string.lstrip()
-
         if lang_string.startswith("<source>"):
-            lang_string = lang_string[8:-10]
-            LANG_STRING_LIST.append(lang_string)
+            LANG_STRING_LIST.append(lang_string[8:-10])
 
     for string in EN_STRINGS:
         if string not in LANG_STRING_LIST:

--- a/languages/diffing_tool.py
+++ b/languages/diffing_tool.py
@@ -1,6 +1,5 @@
 """This module outputs strings missing from other .ts files"""
 import sys
-
 EN_FILE = open("en.ts", "r")
 EN_STRINGS = []
 
@@ -16,7 +15,7 @@ for lang_short in sys.argv[1:]:
 
     for lang_string in LANG_FILE:
         lang_string = lang_string.lstrip()
-        
+
         if lang_string.startswith("<source>"):
             lang_string = lang_string[8:-10]
             LANG_STRING_LIST.append(lang_string)

--- a/languages/diffing_tool.py
+++ b/languages/diffing_tool.py
@@ -1,20 +1,26 @@
 """This module outputs strings missing from other .ts files"""
+import sys
+
 EN_FILE = open("en.ts", "r")
 FR_FILE = open("fr.ts", "r")
-EN_STRINGS, FR_STRINGS = [], []
+EN_STRINGS, LANG_STRINGS = [], []
 
 for en_string in EN_FILE:
     en_string = en_string.lstrip()
     if en_string.startswith("<source>"):
         EN_STRINGS.append(en_string[8:-10])
 
-for fr_string in FR_FILE:
-    fr_string = fr_string.lstrip()
+for arg in sys.argv[1:]:
+    LANG_FILE = arg + ".ts"
+    LANG_STRINGS = []
 
-    if fr_string.startswith("<source>"):
-        fr_string = fr_string[8:-10]
-        FR_STRINGS.append(fr_string)
+    for lang_string in LANG_FILE:
+        lang_string = lang_string.lstrip()
 
-for string in EN_STRINGS:
-    if string not in FR_STRINGS:
-        print string
+        if lang_string.startswith("<source>"):
+            lang_string = lang_string[8:-10]
+            LANG_STRINGS.append(lang_string)
+
+        for string in EN_STRINGS:
+            if string not in LANG_STRINGS:
+                print (string)

--- a/languages/diffing_tool.py
+++ b/languages/diffing_tool.py
@@ -2,25 +2,27 @@
 import sys
 
 EN_FILE = open("en.ts", "r")
-FR_FILE = open("fr.ts", "r")
-EN_STRINGS, LANG_STRINGS = [], []
+EN_STRINGS = []
 
 for en_string in EN_FILE:
     en_string = en_string.lstrip()
     if en_string.startswith("<source>"):
         EN_STRINGS.append(en_string[8:-10])
 
-for arg in sys.argv[1:]:
-    LANG_FILE = arg + ".ts"
-    LANG_STRINGS = []
+for lang_short in sys.argv[1:]:
+    LANG_FILE = open(lang_short + ".ts", "r")
+    DIFF_FILE_OUTPUT = open(lang_short + ".txt", "w")
+    LANG_STRING_LIST, DIFF_LIST = [], []
 
     for lang_string in LANG_FILE:
         lang_string = lang_string.lstrip()
-
+        
         if lang_string.startswith("<source>"):
             lang_string = lang_string[8:-10]
-            LANG_STRINGS.append(lang_string)
+            LANG_STRING_LIST.append(lang_string)
 
-        for string in EN_STRINGS:
-            if string not in LANG_STRINGS:
-                print (string)
+    for string in EN_STRINGS:
+        if string not in LANG_STRING_LIST:
+            DIFF_LIST.append(string)
+
+    [DIFF_FILE_OUTPUT.write(line + "\n") for line in DIFF_LIST]

--- a/languages/diffing_tool.py
+++ b/languages/diffing_tool.py
@@ -24,4 +24,4 @@ for lang_short in sys.argv[1:]:
         if string not in LANG_STRING_LIST:
             DIFF_LIST.append(string)
 
-    [DIFF_FILE_OUTPUT.write(line + "\n") for line in DIFF_LIST]
+    DIFF_LIST = [DIFF_FILE_OUTPUT.write(line + "\n") for line in DIFF_LIST]


### PR DESCRIPTION
E.g run:
`python3 diffing-tool.py fr de nl`
Outputs fr.txt, de.txt, nl.txt with a list of externalised strings not found compared to en file