### PR TITLE
Add diffing tool now ignores case. Produces Capitalized string regardless of case

### DIFF
--- a/languages/diffing_tool.py
+++ b/languages/diffing_tool.py
@@ -1,10 +1,15 @@
-"""This module outputs strings missing from other .ts files"""
+"""`
+This module outputs strings missing from other .ts files
+:param [lang]
+example run: python3 diffing_tool.py de
+python3 diffing_tool.py de nl fr -> produces de.txt, nl.txt, fr.txt
+"""
 import sys
 EN_FILE = open("en.ts", "r")
 EN_STRINGS = []
 
 for en_string in EN_FILE:
-    en_string = en_string.lstrip()
+    en_string = en_string.lstrip().capitalize()
     if en_string.startswith("<source>"):
         EN_STRINGS.append(en_string[8:-10])
 
@@ -14,7 +19,7 @@ for lang_short in sys.argv[1:]:
     LANG_STRING_LIST, DIFF_LIST = [], []
 
     for lang_string in LANG_FILE:
-        lang_string = lang_string.lstrip()
+        lang_string = lang_string.lstrip().capitalize()
         if lang_string.startswith("<source>"):
             LANG_STRING_LIST.append(lang_string[8:-10])
 


### PR DESCRIPTION
Fixes: https://github.com/PhotoFlare/photoflare/issues/62

Producing list of capitalized strings. (give thought if this could case issues)
Also added to module comment to explain how to run.
(Not sure why diff is so bad, did I change line endings?)