### PR TITLE
Generate and upload AppImage, closes #167

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,44 @@ dist: trusty
 
 before_install:
     - sudo add-apt-repository ppa:beineri/opt-qt-5.10.1-trusty -y
+    - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get update
     
-install: 
-    - sudo apt-get -y install libc6 libgraphicsmagick++1-dev qt511base
+install:
+    - sudo apt-get -y install libc6 qt510base qt510tools gcc-8
     - source /opt/qt5*/bin/qt5*-env.sh
 
 script:
-  "/bin/sh -c cd /var/photoflare/ && ./build.sh"
+  - wget "http://ftp.icm.edu.pl/pub/unix/graphics/GraphicsMagick/1.3/GraphicsMagick-1.3.31.tar.xz"
+  - tar -xf GraphicsMagick-*.tar.xz
+  - cd GraphicsMagick-*/
+  - ./configure --prefix=/usr --enable-shared
+  - make -j$(nproc)
+  - sudo make install
+  - cd ..
+  - qmake CONFIG+=release PREFIX=/usr
+  - make -j$(nproc)
+  - make INSTALL_ROOT=appdir -j$(nproc) install ; find appdir/
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - # Workaround to increase compatibility with older systems; see https://github.com/darealshinji/AppImageKit-checkrt for details
+  - mkdir -p appdir/usr/optional/ ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -O ./appdir/usr/optional/exec.so
+  - mkdir -p appdir/usr/optional/libstdc++/ ; cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./appdir/usr/optional/libstdc++/
+  - ( cd appdir ; rm AppRun ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64 -O AppRun ; chmod a+x AppRun)
+  - ./linuxdeployqt*.AppImage --appimage-extract
+  - export PATH=$(readlink -f ./squashfs-root/usr/bin):$PATH
+  - ./squashfs-root/usr/bin/appimagetool -g ./appdir/ PhotoFlare-$VERSION-x86_64.AppImage
 
+after_success:
+  - find appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - # curl --upload-file PhotoFlare*.AppImage https://transfer.sh/PhotoFlare-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh PhotoFlare*.AppImage*
+  
 branches:
-  only:
-    - master
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/installers/deb/DEBIAN/usr/share/applications/photoflare.desktop
+++ b/installers/deb/DEBIAN/usr/share/applications/photoflare.desktop
@@ -8,7 +8,6 @@ Icon=photoflare
 Terminal=false
 Type=Application
 Categories=Graphics;2DGraphics;
-Keywords=photo,image,picture,photography,paint,graphics,editor
+Keywords=photo;image;picture;photography;paint;graphics;editor;
 StartupNotify=false
 MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/pjpeg;image/png;image/svg+xml;image/tiff;image/x-bmp;image/x-gray;image/x-icb;image/x-ico;image/x-png;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-xbitmap;image/x-xpixmap;image/x-pcx;image/x-targa;image/x-tga;image/openraster;
-


### PR DESCRIPTION
## New features
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

## Description
Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/apps) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.

## Related Issue
#167
#172 for Linux

## How Has This Been Tested?
Launched on ubuntu-mate-18.04-desktop-amd64.iso 

## Screenshots (if appropriate):
![](https://user-images.githubusercontent.com/2480569/49900586-3cc9b380-fe5f-11e8-9728-43631a716b9d.png)