### PR TITLE
No longer need to extract linuxdeployqt AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,11 @@ script:
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
-  - # Workaround to increase compatibility with older systems; see https://github.com/darealshinji/AppImageKit-checkrt for details
+  # Workaround to increase compatibility with older systems; see https://github.com/darealshinji/AppImageKit-checkrt for details
   - mkdir -p appdir/usr/optional/ ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -O ./appdir/usr/optional/exec.so
   - mkdir -p appdir/usr/optional/libstdc++/ ; cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./appdir/usr/optional/libstdc++/
   - ( cd appdir ; rm AppRun ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64 -O AppRun ; chmod a+x AppRun)
-  - ./linuxdeployqt*.AppImage --appimage-extract
-  - export PATH=$(readlink -f ./squashfs-root/usr/bin):$PATH
-  - ./squashfs-root/usr/bin/appimagetool -g ./appdir/ PhotoFlare-$VERSION-x86_64.AppImage
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
 
 after_success:
   - find appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq


### PR DESCRIPTION
## Description
No longer need to extract linuxdeployqt AppImage. Simplifies the `.travis.yml` script and speeds up the build a little.

## Related Issue
https://github.com/PhotoFlare/photoflare/pull/174

## How Has This Been Tested?
Built and ran a version using this.