### PR TITLE
fix compiling on lld

### DIFF
--- a/Photoflare.pro
+++ b/Photoflare.pro
@@ -29,7 +29,7 @@ win32 {
 # Project settings for Linux and Hurd. Adjust the paths as needed on your system.
 linux|hurd {
     INCLUDEPATH += /usr/include/GraphicsMagick
-    LIBS += -L/usr/lib -lGraphicsMagick++
+    LIBS += -lGraphicsMagick++
     QMAKE_CXXFLAGS += -fopenmp
     LIBS += -fopenmp
 }


### PR DESCRIPTION
LIBS += -L/usr/lib -lGraphicsMagick++
cause compiling issues on lld (but I see it too on gold) to fix it, use this:
LIBS += -lGraphicsMagick++

solution by @berolinux

more details in bug report: https://github.com/PhotoFlare/photoflare/issues/249
and upstream: https://www.mail-archive.com/llvm-bugs@lists.llvm.org/msg35333.html
