### PR TITLE
appdata: add oars rating (required for flathub)

### DIFF
--- a/io.photoflare.photoflare.appdata.xml
+++ b/io.photoflare.photoflare.appdata.xml
@@ -36,7 +36,7 @@
   <provides>
     <binary>photoflare</binary>
   </provides>
-
+  <content_rating type="oars-1.1" />
   <releases>
     <release version="1.6.2" date="2020-01-26">
       <description>


### PR DESCRIPTION
## New features
n/a

## Description
the oars field is required for flathub.

## Related Issue
#238 

## How Has This Been Tested?
```
flatpak run org.freedesktop.appstream-glib validate io.photoflare.photoflare.appdata.xml
```

## Screenshots (if appropriate):
n/a