### PR TITLE
Pointertool Fill Rectangle

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
     {
         // App details
         app.setApplicationName("photoflare");
-        app.setApplicationVersion("1.6.12");
+        app.setApplicationVersion("1.6.13");
         app.setOrganizationDomain("photoflare.io");
 
         // Setup Default settings

--- a/src/toolSettings/pointersettingswidget.cpp
+++ b/src/toolSettings/pointersettingswidget.cpp
@@ -28,7 +28,6 @@ PointerSettingsWidget::PointerSettingsWidget(QWidget *parent) :
     connect(ui->checkBoxFill, SIGNAL(clicked()), this, SIGNAL(settingsChanged()));
 
     ui->checkBoxStroke->setHidden(true);
-    ui->checkBoxFill->setHidden(true);
     ui->square_sel->setHidden(true); // Hide until we have more selection types available
     ui->circle_sel->setHidden(true);
 }

--- a/src/tools/PointerTool.cpp
+++ b/src/tools/PointerTool.cpp
@@ -42,6 +42,8 @@ public:
     QPoint firstPos;
     QPoint secondPos;
     SelectionMode selectionMode;
+    bool fillEnabled;
+    bool strokeEnabled;
     QImage image;
     QPoint imagePos;
     QRect topLeftCorner;
@@ -326,6 +328,9 @@ void PointerTool::onMouseRelease(const QPoint &pos)
             d->topRightCorner = QRect(selection.at(1).x()-cornerSize,selection.at(1).y(), cornerSize, cornerSize);
             d->bottomRightCorner = QRect(selection.at(2).x()-cornerSize,selection.at(2).y()-cornerSize, cornerSize, cornerSize);
             d->bottomLeftCorner = QRect(selection.at(3).x(),selection.at(3).y()-cornerSize, cornerSize, cornerSize);
+            if(d->fillEnabled) {
+                onFillRect();
+            }
         }
         emit painted(m_paintDevice);
     }
@@ -371,18 +376,12 @@ void PointerTool::onKeyPressed(QKeyEvent *keyEvent)
 
 void PointerTool::setStroke(bool enabled)
 {
-    if(enabled)
-    {
-        d->selectionMode = STROKE;
-    }
+    d->strokeEnabled = enabled;
 }
 
 void PointerTool::setFill(bool enabled)
 {
-    if(enabled)
-    {
-        d->selectionMode = FILL;
-    }
+    d->fillEnabled = enabled;
 }
 
 void PointerTool::setupRightClickMenu(bool execute)
@@ -396,13 +395,6 @@ void PointerTool::setupRightClickMenu(bool execute)
     if(d->firstPos != d->secondPos)
     {
         crop.setDisabled(false);
-    }
-    QAction fillRect(tr("Fill Rectangle"), this);
-    contextMenu.addAction(&fillRect);
-    fillRect.setDisabled(true);
-    if(d->firstPos != d->secondPos)
-    {
-        fillRect.setDisabled(false);
     }
     QAction sep0(this);
     sep0.setSeparator(true);
@@ -441,7 +433,6 @@ void PointerTool::setupRightClickMenu(bool execute)
     contextMenu.addAction(&redo);
 
     connect(&crop, SIGNAL(triggered()), this, SLOT(onCrop()));
-    connect(&fillRect, SIGNAL(triggered()), this, SLOT(onFillRect()));
     connect(&save, SIGNAL(triggered()), this, SLOT(onSave()));
     connect(&saveAs, SIGNAL(triggered()), this, SLOT(onSaveAs()));
     connect(&close, SIGNAL(triggered()), this, SLOT(onClose()));


### PR DESCRIPTION
## New features
Fill rectangle as mentioned in #267.

## Description
The selection tool should be able to fill and stroke rectangles. I have added the setting for fill.

## Related Issue
Based on the work provided in PR #482. After this stroke should be possible.

## How Has This Been Tested?
Tested locally. 

## Screenshots (if appropriate):
![image](https://github.com/PhotoFlare/photoflare/assets/4488048/ee46adf4-45c9-494b-9f57-1d8721bb7174)

