### PR TITLE
Minor version issue in the Photoflare.pro

### DIFF
--- a/Photoflare.pro
+++ b/Photoflare.pro
@@ -1,7 +1,7 @@
 lessThan(QT_MAJOR_VERSION, 6) {
     error("This project requires Qt 6.4.0 or later")
 }
-isEqual(QT_MAJOR_VERSION, 6) : lessThan(QT_MINOR_VERSION, 5) {
+isEqual(QT_MAJOR_VERSION, 6) : lessThan(QT_MINOR_VERSION, 4) {
     error("This project requires Qt 6.4.0 or later")
 }
 

--- a/src/tools/Tool.h
+++ b/src/tools/Tool.h
@@ -25,6 +25,7 @@
 #include <QPainter>
 #include <QCursor>
 #include <QKeyEvent>
+#include <QApplication>
 
 class QPaintDevice;
 


### PR DESCRIPTION
The error message in two places states that Qt 6.4+ is required, however the actual version check was rejecting Qt 6.4 and effectively requiring Qt 6.5+.

While building on Debian with Qt 6.4.2, I spent some time investigating why the build was failing before noticing the mismatch between the error message and the condition.

This change updates the version check so that Qt 6.4.x is accepted, matching the requirement stated in the error message.

## New features

N/A

## Description

Fixed the Qt version check in `Photoflare.pro`.

Previously:

```qmake
isEqual(QT_MAJOR_VERSION, 6) : lessThan(QT_MINOR_VERSION, 5)
```

This rejected all Qt 6.4 releases while displaying an error message claiming that Qt 6.4.0 or later was supported.

The check now correctly accepts Qt 6.4.x releases, making the implementation consistent with the documented requirement.

## Related Issue

N/A

## How Has This Been Tested?

Tested on Debian with Qt 6.4.2.

Before:

* `qmake6 Photoflare.pro` failed with:
  `This project requires Qt 6.4.0 or later`

After:

* `qmake6 Photoflare.pro` completes successfully and proceeds to the compilation stage.

## Screenshots (if appropriate):

N/A
