### PR TITLE
Fix Qt 6.4 version check and missing QApplication include

### DIFF
--- a/Photoflare.pro
+++ b/Photoflare.pro
@@ -1,7 +1,7 @@
 lessThan(QT_MAJOR_VERSION, 6) {
     error("This project requires Qt 6.4.0 or later")
 }
-isEqual(QT_MAJOR_VERSION, 6) : lessThan(QT_MINOR_VERSION, 5) {
+isEqual(QT_MAJOR_VERSION, 6) : lessThan(QT_MINOR_VERSION, 4) {
     error("This project requires Qt 6.4.0 or later")
 }
 

--- a/src/tools/Tool.h
+++ b/src/tools/Tool.h
@@ -25,6 +25,7 @@
 #include <QPainter>
 #include <QCursor>
 #include <QKeyEvent>
+#include <QApplication>
 
 class QPaintDevice;
 


### PR DESCRIPTION
## New features

N/A

## Description

This pull request contains two build-related fixes for Qt 6 builds.

### 1. Fix Qt version requirement check

The project error message states that Qt 6.4.0 or later is required, however the version check in `Photoflare.pro` was rejecting Qt 6.4 releases and effectively requiring Qt 6.5+.

The version check has been updated to correctly accept Qt 6.4.x releases, making the implementation consistent with the documented requirement.

### 2. Add missing QApplication include

Added the required `QApplication` include to resolve compilation errors caused by usage of `qApp`.

Without the include, compilation failed with errors similar to:

```text
'qApp' was not declared in this scope
```

This allows the project to compile correctly with Qt 6 toolchains where the required declaration is not implicitly available.

## Related Issue

N/A

## How Has This Been Tested?

Tested on Debian with Qt 6.4.2.

Before:

* `qmake6 Photoflare.pro` failed with:
  `This project requires Qt 6.4.0 or later`
* Compilation failed due to:
  `'qApp' was not declared in this scope`

After:

* `qmake6 Photoflare.pro` proceeds successfully with Qt 6.4.2.
* Compilation progresses past the `qApp` related errors.

## Screenshots (if appropriate):

N/A
